### PR TITLE
Add withConf "escape hatch" methods to reader and writer builders.

### DIFF
--- a/src/main/scala/it/nerdammer/spark/hbase/HBaseReaderBuilder.scala
+++ b/src/main/scala/it/nerdammer/spark/hbase/HBaseReaderBuilder.scala
@@ -16,7 +16,8 @@ case class HBaseReaderBuilder [R: ClassTag] private[hbase] (
       private[hbase] val columns: Iterable[String] = Seq.empty,
       private[hbase] val startRow: Option[String] = None,
       private[hbase] val stopRow: Option[String] = None,
-      private[hbase] val salting: Iterable[String] = Seq.empty
+      private[hbase] val salting: Iterable[String] = Seq.empty,
+      private[hbase] val conf: Map[String, String] = Map.empty
       )
       (implicit mapper: FieldReader[R], saltingProvider: SaltingProviderFactory[String]) extends Serializable {
 
@@ -57,6 +58,10 @@ case class HBaseReaderBuilder [R: ClassTag] private[hbase] (
       this.copy(salting = salting)
     }
 
+    def withConf(entry: (String, String)) = this.copy(conf = conf + entry)
+
+    def withConf(entries: Map[String, String]) = this.copy(conf = conf ++ entries)
+  
 }
 
 
@@ -80,7 +85,7 @@ trait HBaseReaderBuilderConversions extends Serializable {
   }
 
   def toSimpleHBaseRDD[R: ClassTag](builder: HBaseReaderBuilder[R], saltingLength: Int = 0)(implicit mapper: FieldReader[R], saltingProvider: SaltingProviderFactory[String]): HBaseSimpleRDD[R] = {
-    val hbaseConfig = HBaseSparkConf.fromSparkConf(builder.sc.getConf).createHadoopBaseConfig()
+    val hbaseConfig = HBaseSparkConf.fromSparkConf(builder.sc.getConf).createHadoopBaseConfig(builder.conf)
 
     hbaseConfig.set(TableInputFormat.INPUT_TABLE, builder.table)
 

--- a/src/main/scala/it/nerdammer/spark/hbase/HBaseSparkConf.scala
+++ b/src/main/scala/it/nerdammer/spark/hbase/HBaseSparkConf.scala
@@ -1,5 +1,6 @@
 package it.nerdammer.spark.hbase
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hbase.HBaseConfiguration
 import org.apache.spark.SparkConf
 
@@ -7,13 +8,17 @@ case class HBaseSparkConf (
   hbaseHost: String = HBaseSparkConf.DefaultHBaseHost,
   hbaseRootDir: String = HBaseSparkConf.DefaultHBaseRootDir) extends Serializable {
 
-  def createHadoopBaseConfig() = {
+  def createHadoopBaseConfig() : Configuration = createHadoopBaseConfig(Map())
+
+  def createHadoopBaseConfig(extraConf: Map[String, String]) : Configuration = {
     val conf = HBaseConfiguration.create
     conf.setBoolean("hbase.cluster.distributed", true)
     conf.setInt("hbase.client.scanner.caching", 10000)
     conf.set("hbase.rootdir", hbaseRootDir)
     conf.set("hbase.zookeeper.quorum", hbaseHost)
-
+    for ((key, value) <- extraConf) {
+      conf.set(key, value)
+    }
     conf
   }
 }


### PR DESCRIPTION
This allows custom configuration to be passed per RDD. Example use
cases include:
  * Using Cloud Bigtable without needing to modify hbase-site
  * Using separate HBase clusters per RDD (issue #17)