### PR TITLE
Adding Example - Spark 2.0 with Scala 2.11 - Read from HBase

### DIFF
--- a/examples/spark-2-0-scala-2-11-sample/.gitignore
+++ b/examples/spark-2-0-scala-2-11-sample/.gitignore
@@ -1,0 +1,8 @@
+target/
+*.idea/
+*.iml
+*.iws
+log/
+/out/
+classes/
+

--- a/examples/spark-2-0-scala-2-11-sample/build.sbt
+++ b/examples/spark-2-0-scala-2-11-sample/build.sbt
@@ -1,0 +1,19 @@
+import sbt.ExclusionRule
+name := "Spark-2.0-Scala-2.11-Sample"
+
+version := "1.0"
+
+scalaVersion := "2.11.0"
+
+libraryDependencies += "org.apache.spark" % "spark-sql_2.11" % "2.0.0" excludeAll(ExclusionRule(organization="joda-time"), ExclusionRule(organization="org.slf4j"), ExclusionRule(organization="com.sun.jersey.jersey-test-framework"), ExclusionRule(organization="org.apache.hadoop"))
+libraryDependencies += "it.nerdammer.bigdata" % "spark-hbase-connector_2.10" % "1.0.3"
+libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "2.7.0" excludeAll(ExclusionRule(organization="joda-time"), ExclusionRule(organization="org.slf4j"))
+libraryDependencies += "org.apache.commons" % "commons-exec" % "1.3"
+
+assemblyMergeStrategy in assembly := {
+  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  case x => MergeStrategy.first
+}
+
+
+    

--- a/examples/spark-2-0-scala-2-11-sample/project/build.properties
+++ b/examples/spark-2-0-scala-2-11-sample/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.13

--- a/examples/spark-2-0-scala-2-11-sample/project/plugins.sbt
+++ b/examples/spark-2-0-scala-2-11-sample/project/plugins.sbt
@@ -1,0 +1,2 @@
+logLevel := Level.Warn
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/examples/spark-2-0-scala-2-11-sample/src/main/scala/com/chetan/spark/hbasehivepoc/SparkHBaseTransferHiveJob.scala
+++ b/examples/spark-2-0-scala-2-11-sample/src/main/scala/com/chetan/spark/hbasehivepoc/SparkHBaseTransferHiveJob.scala
@@ -1,0 +1,61 @@
+package com.chetan.spark.hbasehivepoc
+
+/**
+  * Created by chetan on 28/1/17.
+  */
+import it.nerdammer.spark.hbase._
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.SparkSession
+object SparkHBaseTransferHiveJob {
+  val APP_NAME: String = "SparkHbaseJob"
+  var HBASE_DB_HOST: String = null
+  var HBASE_TABLE: String = null
+  var HBASE_COLUMN_FAMILY: String = null
+  var HIVE_DATA_WAREHOUSE: String = null
+  def main(args: Array[String]) = {
+    // Initializing HBASE Configuration variables
+    HBASE_DB_HOST="127.0.0.1"
+    HBASE_TABLE="university"
+    HBASE_COLUMN_FAMILY="emp"
+    // Initializing Hive Metastore configuration
+    HIVE_DATA_WAREHOUSE = "/usr/local/hive/warehouse"
+    // setting spark application
+    val sparkConf = new SparkConf().setAppName(APP_NAME)
+    //initialize the spark context
+    val sparkContext = new SparkContext(sparkConf)
+    //Configuring Hbase host with Spark/Hadoop Configuration
+    sparkContext.hadoopConfiguration.set("spark.hbase.host", HBASE_DB_HOST)
+    // Read HBase Table
+    val hBaseRDD = sparkContext.hbaseTable[(Option[String], Option[String], Option[String], Option[String], Option[String])]("university").select("stid", "name","subject","grade","city").inColumnFamily("emp")
+    // Iterate HBaseRDD and generate RDD[Row]
+    val rowRDD = hBaseRDD.map(i => Row(i._1.get,i._2.get,i._3.get,i._4.get,i._5.get))
+    // Create sqlContext for createDataFrame method
+    val sqlContext = new org.apache.spark.sql.SQLContext(sparkContext)
+    // Create Schema Structure
+    object empSchema {
+      val stid = StructField("stid", StringType)
+      val name = StructField("name", StringType)
+      val subject = StructField("subject", StringType)
+      val grade = StructField("grade", StringType)
+      val city = StructField("city", StringType)
+      val struct = StructType(Array(stid, name, subject, grade, city))
+    }
+
+    import sqlContext.implicits._
+    // Create DataFrame with rowRDD and Schema structure
+    val stdDf = sqlContext.createDataFrame(rowRDD,empSchema.struct);
+    // Enable Hive with Hive warehouse in SparkSession
+    val spark = SparkSession.builder().appName(APP_NAME).config("spark.sql.warehouse.dir", HIVE_DATA_WAREHOUSE).enableHiveSupport().getOrCreate()
+    // Importing spark implicits and sql package
+    import spark.implicits._
+    import spark.sql
+
+    // Saving Dataframe to Hive Table Successfully.
+    stdDf.write.mode("append").saveAsTable("employee")
+
+  }
+}


### PR DESCRIPTION
- Created Example Directory.
- Added Scala 2.11 with SBT 0.13 sample code project which reads from HBase.
- Create View at Spark, save as Internal / external Hive Table